### PR TITLE
iframe support

### DIFF
--- a/client/projector/Program.js
+++ b/client/projector/Program.js
@@ -26,6 +26,15 @@ const canvasSizeMatrix = forwardProjectionMatrixForPoints([
   { x: 0, y: canvasHeight },
 ]).adjugate();
 
+const iframeWidth = 400;
+const iframeHeight = iframeWidth * 1.5;
+const iframeSizeMatrix = forwardProjectionMatrixForPoints([
+  { x: 0, y: 0 },
+  { x: iframeWidth, y: 0 },
+  { x: iframeWidth, y: iframeHeight },
+  { x: 0, y: iframeHeight },
+]).adjugate();
+
 export default class Program extends React.Component {
   constructor(props) {
     super(props);
@@ -190,21 +199,12 @@ export default class Program extends React.Component {
   }
 
   renderIframe() {
-    const iframeWidth = 400;
-    const iframeHeight = iframeWidth * 1.5;
-    const iframeSizeMatrix = forwardProjectionMatrixForPoints([
-      { x: 0, y: 0 },
-      { x: iframeWidth, y: 0 },
-      { x: iframeWidth, y: iframeHeight },
-      { x: 0, y: iframeHeight },
-    ]).adjugate();
-
     const { program } = this.props;
     const matrix = forwardProjectionMatrixForPoints(
       program.points.map(point => mult(point, { x: this.props.width, y: this.props.height }))
     ).multiply(iframeSizeMatrix);
 
-    const canvasStyle = {
+    const iframeStyle = {
       position: 'absolute',
       left: 0,
       top: 0,
@@ -219,7 +219,7 @@ export default class Program extends React.Component {
       <iframe
         key="iframe"
         src={this.state.iframe.src}
-        style={{...canvasStyle }}
+        style={{...iframeStyle }}
       />
     );
   }

--- a/client/projector/Program.js
+++ b/client/projector/Program.js
@@ -190,8 +190,8 @@ export default class Program extends React.Component {
   }
 
   renderIframe() {
-    const iframeWidth = 1000;
-    const iframeHeight = 1500;
+    const iframeWidth = 400;
+    const iframeHeight = iframeWidth * 1.5;
     const iframeSizeMatrix = forwardProjectionMatrixForPoints([
       { x: 0, y: 0 },
       { x: iframeWidth, y: 0 },

--- a/www/api.html
+++ b/www/api.html
@@ -78,4 +78,8 @@
   <p>
     <code>await paper.set('data', { someKey: 'someValue' });</code> will add stuff to the <code>"data"</code> object above, which will be visible to all programs. It will even persist if a program stops running.
   </p>
+
+  <p>
+    <code>await paper.set('iframe', { src: 'http://www.example.com' });</code> will cover your page in an iframe with source at that url.
+  </p>
 </body>


### PR DESCRIPTION
`await paper.set('iframe', { src: 'http://www.example.com' });` will cover your page in an iframe with source at that url.

Hard-coded to have 'pixel' dimensions of 400x600, scaled to fit the page (so dpi will depend on your projector & page size).

Cool for maps, other internet information?

![img_3546](https://user-images.githubusercontent.com/96857/36187316-4382b2d4-10f9-11e8-8673-fb20e2128690.JPG)
