### PR TITLE
ensure that paperProgramsProgramsToRender in localStorage

### DIFF
--- a/client/camera/entry.js
+++ b/client/camera/entry.js
@@ -34,6 +34,10 @@ localStorage.paperProgramsConfig = JSON.stringify(
   })
 );
 
+if (!localStorage.hasOwnProperty('paperProgramsProgramsToRender')) {
+  localStorage.paperProgramsProgramsToRender = JSON.stringify([]);
+}
+
 const element = document.createElement('div');
 document.body.appendChild(element);
 


### PR DESCRIPTION
When running for the first time `paperProgramsProgramsToRender` does not exist in local storage, so an error is thrown. This ensures it exists.