### PR TITLE
Add filtering to paper.get('papers')

### DIFF
--- a/client/projector/Program.js
+++ b/client/projector/Program.js
@@ -119,11 +119,8 @@ export default class Program extends React.Component {
           this.setState({ showSupporterCanvas: true });
         }
       } else if (sendData.name === 'papers') {
-        const thisPaper = this.props.paper[this.props.programNumber];
-        this._worker.postMessage({
-          messageId,
-          receiveData: { object: filterPapers(sendData.data, thisPaper, this.props.papers) }
-        });
+        const filteredPapers = filterPapers(sendData.data, this._program().number, this.props.papers);
+        this._worker.postMessage({ messageId, receiveData: { object: filteredPapers } });
       }
     } else if (command === 'set') {
       if (sendData.name === 'data') {

--- a/client/projector/Program.js
+++ b/client/projector/Program.js
@@ -4,7 +4,11 @@ import sortBy from 'lodash/sortBy';
 import throttle from 'lodash/throttle';
 import xhr from 'xhr';
 
-import { forwardProjectionMatrixForPoints, mult } from '../utils';
+import {
+  forwardProjectionMatrixForPoints,
+  mult,
+  filterPapers
+} from '../utils';
 import styles from './Program.css';
 
 function matrixToCssTransform(matrix) {
@@ -115,7 +119,11 @@ export default class Program extends React.Component {
           this.setState({ showSupporterCanvas: true });
         }
       } else if (sendData.name === 'papers') {
-        this._worker.postMessage({ messageId, receiveData: { object: this.props.papers } });
+        const thisPaper = this.props.paper[this.props.programNumber];
+        this._worker.postMessage({
+          messageId,
+          receiveData: { object: filterPapers(sendData.data, thisPaper, this.props.papers) }
+        });
       }
     } else if (command === 'set') {
       if (sendData.name === 'data') {

--- a/client/utils.js
+++ b/client/utils.js
@@ -183,7 +183,7 @@ export function filterPapers(params, originPaperId, papers) {
   let wisker;
   if (typeof position !== 'undefined') {
     distance = params.distance || 150;
-    closest = params.closest || true;
+    closest = (typeof params.closest === 'undefined') ? true : params.closest;
     wisker = getPaperWisker(originPaper, position, distance);
   }
   let filteredPapers = {};

--- a/client/utils.js
+++ b/client/utils.js
@@ -1,5 +1,6 @@
 import Matrix from 'node-matrices';
 import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
 
 export function norm(vector) {
   if (vector.x !== undefined) return norm([vector.x, vector.y]);
@@ -168,8 +169,11 @@ export function getPaperWisker(paper, direction, length) {
   return [segmentMiddle, wiskerEnd];
 }
 
-export function filterPapers(params, originPaper, papers) {
-  if (typeof params === 'undefined') return papers;
+export function filterPapers(params, originPaperId, papers) {
+  if (typeof params === 'undefined' || isEmpty(params)) {
+    return papers;
+  }
+  const originPaper = papers[originPaperId];
   let position = params.position;
   let distance = params.distance;
   let getClosest = params.getClosest || false;
@@ -187,7 +191,7 @@ export function filterPapers(params, originPaper, papers) {
   for (let paperId in papers) {
     const paper = papers[paperId];
     const points = paper.points;
-    if (!includeSelf && paperId === this.props.programNumber) {
+    if (!includeSelf && paperId === originPaperId) {
       continue;
     }
     if (dataFormat && !validatePaperData(dataFormat, paper.data)) {
@@ -216,4 +220,5 @@ export function filterPapers(params, originPaper, papers) {
       filteredPapers[paperId] = paper;
     }
   }
+  return filteredPapers;
 }

--- a/client/utils.js
+++ b/client/utils.js
@@ -174,6 +174,19 @@ export function getPaperWisker(paper, direction, length) {
   return [segmentMiddle, wiskerEnd];
 }
 
+/**
+ * Filter a set of papers
+ * @param  {object} params        Map of filter parameters
+ * @param  {string} originPaperId The paper that is calling the filter
+ * @param  {object} papers        Map of paper id to paper data (points, data, ...)
+ * @return {object} the filtered set of papers
+ * params supports the following optional arguments:
+ *   "position"  {string}  "up" "right" "down" "left", relative position to origin paper
+ *   "distance"  {number}  how far away a paper can be
+ *   "closet"    {boolean} return only the closest paper?
+ *   "includeMe" {boolean} include the origin paper in the returned papers
+ *   "data"      {object}  check a paper's data format (see validatePaperData())
+ */
 export function filterPapers(params, originPaperId, papers) {
   if (typeof params === 'undefined' || isEmpty(params)) {
     return papers;

--- a/client/utils.js
+++ b/client/utils.js
@@ -181,13 +181,13 @@ export function filterPapers(params, originPaperId, papers) {
   const originPaper = papers[originPaperId];
   let position = params.position;
   let distance = params.distance;
-  let getClosest = params.getClosest || false;
-  let includeSelf = params.includeSelf;
+  let closest = params.closest || false;
+  let includeMe = params.includeMe;
   let dataFormat = params.data;
   let wisker;
   if (typeof position !== 'undefined') {
     distance = params.distance || 150;
-    getClosest = params.getClosest || true;
+    closest = params.closest || true;
     wisker = getPaperWisker(originPaper, position, distance);
   }
   let filteredPapers = {};
@@ -195,7 +195,7 @@ export function filterPapers(params, originPaperId, papers) {
   for (let paperId in papers) {
     const paper = papers[paperId];
     const points = paper.points;
-    if (!includeSelf && paperId === originPaperId) {
+    if (!includeMe && paperId === originPaperId) {
       continue;
     }
     if (dataFormat && !validatePaperData(dataFormat, paper.data)) {
@@ -215,7 +215,7 @@ export function filterPapers(params, originPaperId, papers) {
     } else if (distance && centerDistance > distance) {
       continue;
     }
-    if (getClosest) {
+    if (closest) {
       if (closestDistance === null || centerDistance < closestDistance) {
         closestDistance = centerDistance;
         filteredPapers = {[paperId]: paper};

--- a/client/utils.js
+++ b/client/utils.js
@@ -179,11 +179,7 @@ export function filterPapers(params, originPaperId, papers) {
     return papers;
   }
   const originPaper = papers[originPaperId];
-  let position = params.position;
-  let distance = params.distance;
-  let closest = params.closest || false;
-  let includeMe = params.includeMe;
-  let dataFormat = params.data;
+  let {position, distance, closest, includeMe, data: dataFormat} = params;
   let wisker;
   if (typeof position !== 'undefined') {
     distance = params.distance || 150;

--- a/client/utils.js
+++ b/client/utils.js
@@ -218,7 +218,7 @@ export function filterPapers(params, originPaperId, papers) {
     if (getClosest) {
       if (closestDistance === null || centerDistance < closestDistance) {
         closestDistance = centerDistance;
-        filteredPapers = paper;
+        filteredPapers = {[paperId]: paper};
       }
     } else {
       filteredPapers[paperId] = paper;

--- a/client/utils.js
+++ b/client/utils.js
@@ -1,4 +1,5 @@
 import Matrix from 'node-matrices';
+import isArray from 'lodash/isArray';
 
 export function norm(vector) {
   if (vector.x !== undefined) return norm([vector.x, vector.y]);
@@ -18,6 +19,11 @@ export function diff(v1, v2) {
 export function mult(v1, v2) {
   if (v1.x !== undefined) return { x: v1.x * v2.x, y: v1.y * v2.y };
   return v1.map((value, index) => value * v2[index]);
+}
+
+export function scale(vector, scale) {
+  if (vector.x !== undefined) return { x: vector.x * scale, y: vector.y * scale };
+  return v1.map((value, index) => value * scale);
 }
 
 export function div(v1, v2) {
@@ -79,6 +85,18 @@ export function projectPoint(point, projectionMatrix) {
   };
 }
 
+// Adapted from https://stackoverflow.com/questions/9043805/test-if-two-lines-intersect-javascript-function
+export function intersects(v1,  v2,  v3,  v4) {
+  const det = (v2.x - v1.x) * (v4.y - v3.y) - (v4.x - v3.x) * (v2.y - v1.y);
+  if (det === 0) {
+    return false;
+  } else {
+    const lambda = ((v4.y - v3.y) * (v4.x - v1.x) + (v3.x - v4.x) * (v4.y - v1.y)) / det;
+    const gamma = ((v1.y - v2.y) * (v4.x - v1.x) + (v2.x - v1.x) * (v4.y - v1.y)) / det;
+    return (0 < lambda && lambda < 1) && (0 < gamma && gamma < 1);
+  }
+};
+
 export function getApiUrl(spaceName, suffix) {
   return new URL(`api/spaces/${spaceName}${suffix}`, window.location.origin).toString();
 }
@@ -98,4 +116,104 @@ export function codeToPrint(code) {
     if (!lines[i].match(commentRegex) && lines[i].trim().length !== 0) break;
   }
   return lines.slice(i).join('\n');
+}
+
+/**
+ * Check if a paper's data matches a given format
+ * @param  {Array}   dataFormat List of rules to validate the data against
+ *     ex: [{name: "coords", items: [{name: "lat", type: "Number"}, {name: "long", type: "Number"}]}]
+ * @param  {Object}  data       A paper's data object
+ *     ex: {"coords": [{lat: 93.01, long: 23.12}, {lat: 93.40, long: 23.49}]}
+ * @return {Boolean}
+ */
+function validatePaperData(dataFormat, data) {
+  dataFormatLoop:
+  for (let i in dataFormat) {
+    const format = dataFormat[i];
+    for (let key in data) {
+      const value = data[key];
+      const validName = typeof format.name === 'undefined' || format.name == key;
+      const validType = typeof format.type === 'undefined' || format.type == typeof dataKey;
+      // only check the format of the first list item, for speed and simplicity
+      const validItems = typeof format.items === 'undefined' || (
+        isArray(value) && (value.length === 0 || validatePaperData(format.items, value[0]))
+      );
+      if (validName && validType && validItems) {
+        continue dataFormatLoop;
+      }
+    }
+    if (typeof format.required === 'undefined' || format.required) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function getPaperWisker(paper, direction, length) {
+  const pts = paper.points;
+  const segment = (dir => {
+    switch(dir) {
+      case 'right':
+        return [pts.topRight, pts.bottomRight];
+      case 'down':
+        return [pts.bottomRight, pts.bottomLeft];
+      case 'left':
+        return [pts.bottomLeft, pts.topLeft];
+      default:
+        return [pts.topRight, pts.topLeft];
+    }
+  })(direction);
+  const segmentMiddle = scale(diff(...directionSegment), 0.5);
+  const wiskerEnd = moveAlongVector(length, diff(segmentMiddle, pts.center));
+  return [segmentMiddle, wiskerEnd];
+}
+
+export function filterPapers(params, originPaper, papers) {
+  if (typeof params === 'undefined') return papers;
+  let position = params.position;
+  let distance = params.distance;
+  let getClosest = params.getClosest || false;
+  let includeSelf = params.includeSelf || true;
+  let dataFormat = params.data;
+  let wisker;
+  if (typeof position !== 'undefined') {
+    distance = params.distance || 150;
+    getClosest = params.getClosest || true;
+    includeSelf = params.includeSelf || false;
+    wisker = getPaperWisker(originPaper, position, distance);
+  }
+  let filteredPapers = {};
+  let closestDistance = null;
+  for (let paperId in papers) {
+    const paper = papers[paperId];
+    const points = paper.points;
+    if (!includeSelf && paperId === this.props.programNumber) {
+      continue;
+    }
+    if (dataFormat && !validatePaperData(dataFormat, paper.data)) {
+      continue;
+    }
+    const centerDistance = norm(diff(originPaper.points.center, points.center));
+    if (position && wisker) {
+      const paperIntersectsWisker = (
+        intersects(...wisker, points.topLeft, points.topRight) ||
+        intersects(...wisker, points.topRight, points.bottomRight) ||
+        intersects(...wisker, points.bottomRight, points.bottomLeft) ||
+        intersects(...wisker, points.bottomLeft, points.topLeft)
+      )
+      if (!paperIntersectsWisker) {
+        continue;
+      }
+    } else if (distance && centerDistance > distance) {
+      continue;
+    }
+    if (getClosest) {
+      if (closestDistance === null || centerDistance < closestDistance) {
+        closestDistance = centerDistance;
+        filteredPapers = paper;
+      }
+    } else {
+      filteredPapers[paperId] = paper;
+    }
+  }
 }

--- a/client/utils.js
+++ b/client/utils.js
@@ -177,13 +177,12 @@ export function filterPapers(params, originPaperId, papers) {
   let position = params.position;
   let distance = params.distance;
   let getClosest = params.getClosest || false;
-  let includeSelf = params.includeSelf || true;
+  let includeSelf = params.includeSelf;
   let dataFormat = params.data;
   let wisker;
   if (typeof position !== 'undefined') {
     distance = params.distance || 150;
     getClosest = params.getClosest || true;
-    includeSelf = params.includeSelf || false;
     wisker = getPaperWisker(originPaper, position, distance);
   }
   let filteredPapers = {};

--- a/client/utils.js
+++ b/client/utils.js
@@ -163,8 +163,8 @@ export function getPaperWisker(paper, direction, length) {
         return [pts.topRight, pts.topLeft];
     }
   })(direction);
-  const segmentMiddle = scale(diff(...directionSegment), 0.5);
-  const wiskerEnd = moveAlongVector(length, diff(segmentMiddle, pts.center));
+  const segmentMiddle = add(segment[1], scale(diff(...segment), 0.5));
+  const wiskerEnd = add(segmentMiddle, moveAlongVector(length, diff(segmentMiddle, pts.center)));
   return [segmentMiddle, wiskerEnd];
 }
 


### PR DESCRIPTION
I found that a lot of programs where long because I was iterating through all papers to find the paper that was above my paper, find the closest paper with a particular format of data, find if any paper had a particular label, etc.  This PR extends `paper.get('papers')` to include an optional second argument to filter papers.

Example uses:
```
const papers = await paper.get('papers', { position: "up", data: {value: "head"} });
if (Object.keys(papers).length === 1) {
  console.log("A head is above of me.");
}
```

```
const papers = await paper.get('papers', { distance: 400 });
if (Object.keys(papers).length > 0) {
  console.log("Someone is too close!");
}
```

```
const closestMapDataPaper = await paper.get('papers', { closest: true, data: { items: [
  { name: "latitude", type: "number" },
  { name: "longitude", type: "number" }
] } });

// Matches to the closest paper with a code like:

await paper.set('data', { list: [
  {
    "state":"Alaska",
    "latitude":61.3850,
    "longitude":-152.2683
  },
  {
    "state":"Alabama",
    "latitude":32.7990,
    "longitude":-86.8073
  }
] });
```

```
const allPapersButMe = await paper.get('papers', { includeMe: false });
```
