### PR TITLE
Edit Dynamicland section of front page, add comparison table

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -68,6 +68,24 @@
     .faq a:active, .faq a:hover {
       color: #666;
     }
+
+    .highlight {
+      background-color: yellow;
+    }
+
+    table {
+      width: 100%;
+    }
+
+    table, td, th {
+      border: 2px solid black;
+      border-collapse: collapse;
+    }
+
+    td, th {
+      padding: 10px;
+      text-align: center;
+    }
   </style>
 </head>
 <body style="width: 1080px; margin: 0 auto; padding: 0; line-height: 0; position: relative">
@@ -120,6 +138,10 @@
 
       <p>
         <strong>How is Paper Programs related to  <a href="https://dynamicland.org">Dynamicland</a>?</strong><br>
+        <span class="highlight">Paper Programs recreates just a tiny part of what makes Dynamicland so interesting</span>. To learn more about their system and vision, be sure to visit Dynamicland in Oakland -- and please consider donating, too!
+      </p>
+
+      <p>
         Paper Programs is inspired by the projector and camera setup of the 2017 iteration of Dynamicland. I liked how you could <em>physically hold a program in your hands</em>, and then put on any surface in the building, where it would start executing, as if by magic. And I liked how people <em>naturally started collaborating</em>, writing programs that interact with each other.
       </p>
 
@@ -128,7 +150,24 @@
       </p>
 
       <p>
-        Paper Programs is not a clone of Dynamicland. To learn more about their system and vision, be sure to visit Dynamicland in Oakland.
+        In short, Paper Programs gets you a limited version of the interaction model of Dynamicland, but not the other parts:
+        <table>
+          <tr>
+            <th></th>
+            <th><strong>Paper Programs</strong></th>
+            <th><strong>Dynamicland</strong></th>
+          </tr>
+          <tr>
+            <td><strong>Platform</strong></td>
+            <td>Chrome with experimental flags enabled</td>
+            <td class="highlight">Realtalk OS</td>
+          </tr>
+          <tr>
+            <td><strong>Contributors</strong></td>
+            <td>People with spare time</td>
+            <td class="highlight">Dedicated research team</td>
+          </tr>
+        </table>
       </p>
 
       <p>


### PR DESCRIPTION
This PR edits the "How is Paper Programs related to Dynamicland?" section of the front page to address #32 a bit, and also adds a comparison table that makes it clear what Dynamicland Does that Paper Programs don't!

What other rows could be added to this table to dissuade anybody from thinking they could use Paper Programs as an alternative for working with Dynamicland? Three rows seems like a nice round figure.

After making all these PRs that kind of disparage Paper Programs I'm looking forward to contributing some more positive additions 😄 

Screenshot:

<img width="842" alt="screen shot 2018-03-22 at 13 25 31" src="https://user-images.githubusercontent.com/579491/37770432-af5f0c3a-2dd4-11e8-9f44-cf9ff57bf784.png">
