### PR TITLE
Replace zoom slider with mouse wheel

### DIFF
--- a/client/camera/CameraMain.js
+++ b/client/camera/CameraMain.js
@@ -138,7 +138,6 @@ export default class CameraMain extends React.Component {
           <div className={styles.video}>
             <CameraVideo
               width={this.state.pageWidth - padding * 3 - sidebarWidth}
-              zoom={this.props.config.zoom}
               config={this.props.config}
               onConfigChange={this.props.onConfigChange}
               onProcessVideo={({ programsToRender, framerate }) => {
@@ -239,20 +238,6 @@ export default class CameraMain extends React.Component {
                 />{' '}
                 show printed in queue
               </div>
-            </div>
-
-            <div className={styles.sidebarSection}>
-              zoom{' '}
-              <input
-                type="range"
-                min="1"
-                max="4"
-                step="0.25"
-                value={this.props.config.zoom}
-                onChange={event =>
-                  this.props.onConfigChange({ ...this.props.config, zoom: event.target.value })
-                }
-              />
             </div>
 
             <div className={styles.sidebarSection}>

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -61,6 +61,7 @@ export default class CameraVideo extends React.Component {
     };
     document.body.addEventListener('mousemove', mouseMoveHandler, true);
     document.body.addEventListener('mouseup', mouseUpHandler, true);
+    mouseDownEvent.preventDefault();
   };
 
   _processVideo = () => {

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -51,10 +51,13 @@ export default class CameraVideo extends React.Component {
     const surface = d3.select(this._zoomSurface);
 
     // create zoom object and update event
-    const zoom = d3.zoom().on('zoom', () => {
-      const { x, y, k } = d3.event.transform;
-      this.props.onConfigChange({ ...this.props.config, zoomTransform: { x, y, k } });
-    });
+    const zoom = d3
+      .zoom()
+      .scaleExtent([1, 4])
+      .on('zoom', () => {
+        const { x, y, k } = d3.event.transform;
+        this.props.onConfigChange({ ...this.props.config, zoomTransform: { x, y, k } });
+      });
 
     // initialize zoom
     const { x, y, k } = this.props.config.zoomTransform;

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -51,18 +51,18 @@ export default class CameraVideo extends React.Component {
     const surface = d3.select(this._zoomSurface);
 
     // create zoom object and update event
-    const zoom = d3.zoom().on("zoom", () => {
-      const {x,y,k} = d3.event.transform;
-      this.props.onConfigChange({...this.props.config, zoomTransform: {x,y,k}});
+    const zoom = d3.zoom().on('zoom', () => {
+      const { x, y, k } = d3.event.transform;
+      this.props.onConfigChange({ ...this.props.config, zoomTransform: { x, y, k } });
     });
 
     // initialize zoom
-    const {x,y,k} = this.props.config.zoomTransform;
-    surface.call(zoom.transform, d3.zoomIdentity.translate(x,y).scale(k));
+    const { x, y, k } = this.props.config.zoomTransform;
+    surface.call(zoom.transform, d3.zoomIdentity.translate(x, y).scale(k));
 
     // attach zoom handler
     surface.call(zoom);
-  }
+  };
 
   _processVideo = () => {
     setTimeout(this._processVideo);
@@ -95,14 +95,10 @@ export default class CameraVideo extends React.Component {
   render() {
     const width = this.props.width;
     const height = width / this.state.videoWidth * this.state.videoHeight;
-
-    const {x,y,k} = this.props.config.zoomTransform;
+    const { x, y, k } = this.props.config.zoomTransform;
 
     return (
-      <div
-        ref={el => (this._el = el)}
-        style={{ width, height, overflow: 'hidden' }}
-      >
+      <div ref={el => (this._el = el)} style={{ width, height, overflow: 'hidden' }}>
         <video id="videoInput" style={{ display: 'none' }} ref={el => (this._videoInput = el)} />
         <div
           style={{
@@ -117,7 +113,7 @@ export default class CameraVideo extends React.Component {
             style={{
               position: 'absolute',
               transform: `translate(${x}px, ${y}px) scale(${k})`,
-              transformOrigin: "0 0",
+              transformOrigin: '0 0',
               width: `${width}px`,
               height: `${height}px`,
             }}
@@ -135,7 +131,7 @@ export default class CameraVideo extends React.Component {
                   const knobPoints = this.props.config.knobPoints.slice();
                   knobPoints[position] = {
                     x: (newPoint.x - x) / k / width,
-                    y: (newPoint.y - y) / k / height
+                    y: (newPoint.y - y) / k / height,
                   };
                   this.props.onConfigChange({ ...this.props.config, knobPoints });
                 }}
@@ -143,19 +139,24 @@ export default class CameraVideo extends React.Component {
             );
           })}
           {this.props.allowSelectingDetectedPoints &&
-            this.state.keyPoints.map((point, index) => (
-              <div
-                key={index}
-                className={styles.keyPoint}
-                style={{
-                  left: (point.pt.x - point.size / 2) / this.state.videoWidth * width,
-                  top: (point.pt.y - point.size / 2) / this.state.videoHeight * height,
-                  width: point.size / this.state.videoWidth * width,
-                  height: point.size / this.state.videoHeight * height,
-                }}
-                onClick={() => this.props.onSelectColor(point.avgColor)}
-              />
-            ))}
+            this.state.keyPoints.map((point, index) => {
+              const px = (point.pt.x - point.size / 2) / this.state.videoWidth * width * k + x;
+              const py = (point.pt.y - point.size / 2) / this.state.videoHeight * height * k + y;
+              const pw = point.size / this.state.videoWidth * width * k;
+              const ph = point.size / this.state.videoHeight * height * k;
+              return (
+                <div
+                  key={index}
+                  className={styles.keyPoint}
+                  style={{
+                    transform: `translate(${px}px, ${py}px)`,
+                    width: `${pw}px`,
+                    height: `${ph}px`,
+                  }}
+                  onClick={() => this.props.onSelectColor(point.avgColor)}
+                />
+              );
+            })}
         </div>
       </div>
     );

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -150,7 +150,6 @@ export default class CameraVideo extends React.Component {
                   key={index}
                   className={styles.keyPoint}
                   style={{
-                    position: 'absolute',
                     transform: `translate(${px}px, ${py}px) scale(${k})`,
                     transformOrigin: '0 0',
                     width: point.size / this.state.videoWidth * width,

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -117,8 +117,8 @@ export default class CameraVideo extends React.Component {
               position: 'absolute',
               transform: `translate(${x}px, ${y}px) scale(${k})`,
               transformOrigin: '0 0',
-              width: `${width}px`,
-              height: `${height}px`,
+              width,
+              height,
             }}
             ref={el => (this._canvas = el)}
           />
@@ -145,16 +145,16 @@ export default class CameraVideo extends React.Component {
             this.state.keyPoints.map((point, index) => {
               const px = (point.pt.x - point.size / 2) / this.state.videoWidth * width * k + x;
               const py = (point.pt.y - point.size / 2) / this.state.videoHeight * height * k + y;
-              const pw = point.size / this.state.videoWidth * width * k;
-              const ph = point.size / this.state.videoHeight * height * k;
               return (
                 <div
                   key={index}
                   className={styles.keyPoint}
                   style={{
-                    transform: `translate(${px}px, ${py}px)`,
-                    width: `${pw}px`,
-                    height: `${ph}px`,
+                    position: 'absolute',
+                    transform: `translate(${px}px, ${py}px) scale(${k})`,
+                    transformOrigin: '0 0',
+                    width: point.size / this.state.videoWidth * width,
+                    height: point.size / this.state.videoHeight * height,
                   }}
                   onClick={() => this.props.onSelectColor(point.avgColor)}
                 />

--- a/client/camera/Knob.js
+++ b/client/camera/Knob.js
@@ -1,29 +1,27 @@
 import React from 'react';
 import styles from './Knob.css';
+import * as d3 from 'd3';
 
 export default class Knob extends React.Component {
-  _onMouseDown = mouseDownEvent => {
-    const mouseMoveHandler = event => {
-      const parentOffset = this._el.offsetParent.getBoundingClientRect();
-      this.props.onChange({
-        x: event.clientX - parentOffset.left,
-        y: event.clientY - parentOffset.top,
-      });
-    };
-    const mouseUpHandler = () => {
-      document.body.removeEventListener('mousemove', mouseMoveHandler, true);
-      document.body.removeEventListener('mouseup', mouseUpHandler, true);
-    };
-    document.body.addEventListener('mousemove', mouseMoveHandler, true);
-    document.body.addEventListener('mouseup', mouseUpHandler, true);
-    mouseDownEvent.preventDefault();
-  };
-
+  componentDidMount() {
+    this._attachDragger();
+  }
+  _attachDragger = () => {
+    const dragger = d3.drag().on("drag", () => {
+      const {x,y} = d3.event;
+      this.props.onChange({x,y});
+    });
+    d3.select(this._el).call(dragger);
+  }
   render() {
+    const {x,y} = this.props;
     return (
       <div
         className={styles.knob}
-        style={{ left: this.props.x, top: this.props.y }}
+        style={{
+          position: 'absolute',
+          transform: `translate(${x}px,${y}px)`
+        }}
         onMouseDown={this._onMouseDown}
         ref={el => (this._el = el)}
       >

--- a/client/camera/Knob.js
+++ b/client/camera/Knob.js
@@ -7,22 +7,27 @@ export default class Knob extends React.Component {
     this._attachDragger();
   }
   _attachDragger = () => {
-    const dragger = d3.drag().on("drag", () => {
-      const {x,y} = d3.event;
-      this.props.onChange({x,y});
-    });
+    const dragger = d3
+      .drag()
+      .subject(() => {
+        const { x, y } = this.props;
+        return { x, y };
+      })
+      .on('drag', () => {
+        const { x, y } = d3.event;
+        this.props.onChange({ x, y });
+      });
     d3.select(this._el).call(dragger);
-  }
+  };
   render() {
-    const {x,y} = this.props;
+    const { x, y } = this.props;
     return (
       <div
         className={styles.knob}
         style={{
           position: 'absolute',
-          transform: `translate(${x}px,${y}px)`
+          transform: `translate(${x}px,${y}px)`,
         }}
-        onMouseDown={this._onMouseDown}
         ref={el => (this._el = el)}
       >
         {this.props.label}

--- a/client/camera/Knob.js
+++ b/client/camera/Knob.js
@@ -25,7 +25,6 @@ export default class Knob extends React.Component {
       <div
         className={styles.knob}
         style={{
-          position: 'absolute',
           transform: `translate(${x}px,${y}px)`,
         }}
         ref={el => (this._el = el)}

--- a/client/camera/Knob.js
+++ b/client/camera/Knob.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './Knob.css';
 
 export default class Knob extends React.Component {
-  _onMouseDown = () => {
+  _onMouseDown = mouseDownEvent => {
     const mouseMoveHandler = event => {
       const parentOffset = this._el.offsetParent.getBoundingClientRect();
       this.props.onChange({
@@ -16,6 +16,7 @@ export default class Knob extends React.Component {
     };
     document.body.addEventListener('mousemove', mouseMoveHandler, true);
     document.body.addEventListener('mouseup', mouseUpHandler, true);
+    mouseDownEvent.preventDefault();
   };
 
   render() {

--- a/client/camera/Knob.js
+++ b/client/camera/Knob.js
@@ -10,6 +10,7 @@ export default class Knob extends React.Component {
     const dragger = d3
       .drag()
       .subject(() => {
+        // drag origin
         const { x, y } = this.props;
         return { x, y };
       })

--- a/client/camera/entry.js
+++ b/client/camera/entry.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import uuidv4 from 'uuid/v4';
+import * as d3 from 'd3';
 
 import CameraMain from './CameraMain';
 
 const defaultConfig = {
   colorsRGB: [[119, 43, 24, 255], [94, 104, 48, 255], [65, 80, 84, 255], [0, 0, 0, 255]],
   knobPoints: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 1 }],
-  zoom: 1,
-  zoomCanvasX: 0,
-  zoomCanvasY: 0,
+  zoomTransform: d3.zoomIdentity,
   showOverlayKeyPointCircles: true,
   showOverlayKeyPointText: true,
   showOverlayComponentLines: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1931,6 +1931,270 @@
         "es5-ext": "0.10.39"
       }
     },
+    "d3": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-5.0.0.tgz",
+      "integrity": "sha512-JAuq1vvO8AQnAvZ5Gi3OsUWAoB1dOZlIQZEcj+JzEnafmwLlrWcW24o5I7fM9x+tsrZpsi8n9L12iHyHr0HTlg==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-axis": "1.0.8",
+        "d3-brush": "1.0.4",
+        "d3-chord": "1.0.4",
+        "d3-collection": "1.0.4",
+        "d3-color": "1.0.3",
+        "d3-contour": "1.2.0",
+        "d3-dispatch": "1.0.3",
+        "d3-drag": "1.2.1",
+        "d3-dsv": "1.0.8",
+        "d3-ease": "1.0.3",
+        "d3-fetch": "1.1.0",
+        "d3-force": "1.1.0",
+        "d3-format": "1.2.2",
+        "d3-geo": "1.10.0",
+        "d3-hierarchy": "1.1.5",
+        "d3-interpolate": "1.1.6",
+        "d3-path": "1.0.5",
+        "d3-polygon": "1.0.3",
+        "d3-quadtree": "1.0.3",
+        "d3-random": "1.1.0",
+        "d3-scale": "2.0.0",
+        "d3-scale-chromatic": "1.2.0",
+        "d3-selection": "1.3.0",
+        "d3-shape": "1.2.0",
+        "d3-time": "1.0.8",
+        "d3-time-format": "2.1.1",
+        "d3-timer": "1.0.7",
+        "d3-transition": "1.1.1",
+        "d3-voronoi": "1.1.2",
+        "d3-zoom": "1.7.1"
+      }
+    },
+    "d3-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
+      "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+    },
+    "d3-axis": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
+      "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo="
+    },
+    "d3-brush": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
+      "integrity": "sha1-AMLyOAGfJPbAoZSibUGhUw/+e8Q=",
+      "requires": {
+        "d3-dispatch": "1.0.3",
+        "d3-drag": "1.2.1",
+        "d3-interpolate": "1.1.6",
+        "d3-selection": "1.3.0",
+        "d3-transition": "1.1.1"
+      }
+    },
+    "d3-chord": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
+      "integrity": "sha1-fexPC6iG9xP+ERxF92NBT290yiw=",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-path": "1.0.5"
+      }
+    },
+    "d3-collection": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
+      "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
+    },
+    "d3-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
+      "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+    },
+    "d3-contour": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.2.0.tgz",
+      "integrity": "sha512-nDzZ2KDnrgTrhMjV8TH0RNrljk6uPNAGkG/v/1SKNVvJa2JU8szjh7o2ZYTX8yufA2oCI5HyeMqbzwiB+oDoIA==",
+      "requires": {
+        "d3-array": "1.2.1"
+      }
+    },
+    "d3-dispatch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
+      "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg="
+    },
+    "d3-drag": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
+      "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+      "requires": {
+        "d3-dispatch": "1.0.3",
+        "d3-selection": "1.3.0"
+      }
+    },
+    "d3-dsv": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
+      "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+      "requires": {
+        "commander": "2.15.0",
+        "iconv-lite": "0.4.19",
+        "rw": "1.3.3"
+      }
+    },
+    "d3-ease": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
+      "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
+    },
+    "d3-fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.0.tgz",
+      "integrity": "sha512-j+V4vtT6dceQbcKYLtpTueB8Zvc+wb9I93WaFtEQIYNADXl0c1ZJMN3qQo0CssiTsAqK8pePwc7f4qiW+b0WOg==",
+      "requires": {
+        "d3-dsv": "1.0.8"
+      }
+    },
+    "d3-force": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
+      "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+      "requires": {
+        "d3-collection": "1.0.4",
+        "d3-dispatch": "1.0.3",
+        "d3-quadtree": "1.0.3",
+        "d3-timer": "1.0.7"
+      }
+    },
+    "d3-format": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+      "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+    },
+    "d3-geo": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.10.0.tgz",
+      "integrity": "sha512-VK/buVGgexthTTqGRNXQ/LSo3EbOFu4p2Pjud5drSIaEnOaF2moc8A3P7WEljEO1JEBEwbpAJjFWMuJiUtoBcw==",
+      "requires": {
+        "d3-array": "1.2.1"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
+      "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY="
+    },
+    "d3-interpolate": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+      "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+      "requires": {
+        "d3-color": "1.0.3"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
+      "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
+    },
+    "d3-polygon": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
+      "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI="
+    },
+    "d3-quadtree": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
+      "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
+    },
+    "d3-random": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
+      "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM="
+    },
+    "d3-scale": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.0.0.tgz",
+      "integrity": "sha512-Sa2Ny6CoJT7x6dozxPnvUQT61epGWsgppFvnNl8eJEzfJBG0iDBBTJAtz2JKem7Mb+NevnaZiDiIDHsuWkv6vg==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-collection": "1.0.4",
+        "d3-format": "1.2.2",
+        "d3-interpolate": "1.1.6",
+        "d3-time": "1.0.8",
+        "d3-time-format": "2.1.1"
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.2.0.tgz",
+      "integrity": "sha512-qQUhLi8fPe/F0b0M46C6eFUbms5IIMHuhJ5DKjjzBUvm1b6aPtygJzGbrMdMUD/ckLBq+NdWwHeN2cpMDp4Q5Q==",
+      "requires": {
+        "d3-color": "1.0.3",
+        "d3-interpolate": "1.1.6"
+      }
+    },
+    "d3-selection": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+      "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
+    },
+    "d3-shape": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
+      "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
+      "requires": {
+        "d3-path": "1.0.5"
+      }
+    },
+    "d3-time": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+      "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+    },
+    "d3-time-format": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+      "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+      "requires": {
+        "d3-time": "1.0.8"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
+      "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
+    },
+    "d3-transition": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
+      "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
+      "requires": {
+        "d3-color": "1.0.3",
+        "d3-dispatch": "1.0.3",
+        "d3-ease": "1.0.3",
+        "d3-interpolate": "1.1.6",
+        "d3-selection": "1.3.0",
+        "d3-timer": "1.0.7"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
+    "d3-zoom": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
+      "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
+      "requires": {
+        "d3-dispatch": "1.0.3",
+        "d3-drag": "1.2.1",
+        "d3-interpolate": "1.1.6",
+        "d3-selection": "1.3.0",
+        "d3-transition": "1.1.1"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -7743,6 +8007,11 @@
       "requires": {
         "aproba": "1.2.0"
       }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rx-lite": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "color-diff": "^1.1.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.10",
+    "d3": "^4.13.0",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "heroku-ssl-redirect": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "color-diff": "^1.1.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.10",
-    "d3": "^4.13.0",
+    "d3": "^5.0.0",
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "heroku-ssl-redirect": "0.0.4",


### PR DESCRIPTION
_Wanted to offer these UX improvements in case there was interest. Feel free to close if the value isn't worth the code delta._

1. Panning/zooming uses [d3-zoom](https://github.com/d3/d3-zoom), which allows you to zoom by scrolling or double-clicking:
    ![zoom](https://user-images.githubusercontent.com/116838/37806121-4847d2b0-2e0c-11e8-9396-88ade4b9e857.gif)
2. Corner knobs use [d3-drag](https://github.com/d3/d3-drag), which prevents them from snapping to the center of the cursor:
    ![knob](https://user-images.githubusercontent.com/116838/37806514-649819aa-2e0e-11e8-95e1-cdeb9c29da97.gif)

