### PR TITLE
Program data includes camera picture of program

### DIFF
--- a/client/camera/detectPrograms.js
+++ b/client/camera/detectPrograms.js
@@ -18,6 +18,7 @@ import {
 import { code8400 } from '../dotCodes';
 import { colorNames, cornerNames } from '../constants';
 import simpleBlobDetector from './simpleBlobDetector';
+import programPicture from './programPicture';
 
 function keyPointToAvgColor(keyPoint, videoMat) {
   const x = Math.floor(keyPoint.pt.x - keyPoint.size / 2);
@@ -398,6 +399,8 @@ export default function detectPrograms({ config, videoCapture, dataToRemember, d
     }
   });
 
+  addPicturesToPrograms(programsToRender, config, videoCapture);
+
   videoMat.delete();
 
   return {
@@ -407,3 +410,13 @@ export default function detectPrograms({ config, videoCapture, dataToRemember, d
     framerate: Math.round(1000 / (Date.now() - startTime)),
   };
 }
+
+function addPicturesToPrograms(programsToRender, config, videoCapture) {
+  programsToRender.forEach((programToRender) => {
+    programToRender.picture = programPicture({
+      config,
+      videoCapture,
+      programToRender
+    });
+  });
+};

--- a/client/camera/programPicture.js
+++ b/client/camera/programPicture.js
@@ -1,0 +1,54 @@
+/* global cv */
+
+import { clamp } from '../utils';
+
+export default function programPicture({ config, videoCapture, programToRender }) {
+  const videoMat = new cv.Mat(videoCapture.video.height, videoCapture.video.width, cv.CV_8UC4);
+  videoCapture.read(videoMat);
+
+  const videoROI = pointsToROI(config.knobPoints, videoMat);
+  const clippedVideoMat = videoMat.roi(videoROI);
+  const paperROI = pointsToROI(programToRender.points, clippedVideoMat);
+  const paperVideoMat = clippedVideoMat.roi(paperROI);
+
+  const rgbaPaperVideoMat = new cv.Mat(paperVideoMat.rows, paperVideoMat.cols, cv.CV_8UC4);
+  cv.cvtColor(paperVideoMat, rgbaPaperVideoMat, cv.COLOR_RGB2RGBA);
+
+  const picture = matToStorablePicture(rgbaPaperVideoMat);
+
+  videoMat.delete();
+  clippedVideoMat.delete();
+  paperVideoMat.delete();
+  rgbaPaperVideoMat.delete();
+
+  return picture;
+};
+
+function pointsToROI(points, videoMat) {
+  const clampedPoints = points.map(point => ({
+    x: clamp(point.x, 0, 1),
+    y: clamp(point.y, 0, 1)
+  }));
+  const minX = Math.min(...clampedPoints.map(point => point.x * videoMat.cols));
+  const minY = Math.min(...clampedPoints.map(point => point.y * videoMat.rows));
+  const maxX = Math.max(...clampedPoints.map(point => point.x * videoMat.cols));
+  const maxY = Math.max(...clampedPoints.map(point => point.y * videoMat.rows));
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+};
+
+function copyImageDataToArray(mat) {
+  let data = [];
+  for (let i = 0; i < mat.data.length; i++) {
+    data[i] = mat.data[i];
+  }
+
+  return data;
+};
+
+function matToStorablePicture(mat) {
+  return {
+    width: mat.cols,
+    height: mat.rows,
+    data: copyImageDataToArray(mat)
+  };
+};

--- a/client/projector/ProjectorMain.js
+++ b/client/projector/ProjectorMain.js
@@ -26,6 +26,7 @@ export default class ProjectorMain extends React.Component {
           bottomLeft: mult(program.points[3], multPoint),
           center: mult(centerPoint, multPoint),
         },
+        picture: decodeImageData(program.picture),
         data: this.props.dataByProgramNumber[program.number] || {},
       };
 
@@ -60,3 +61,9 @@ export default class ProjectorMain extends React.Component {
     );
   }
 }
+
+function decodeImageData(picture) {
+  return new ImageData(new Uint8ClampedArray(picture.data),
+                       picture.width,
+                       picture.height);
+};

--- a/www/api.html
+++ b/www/api.html
@@ -65,7 +65,8 @@
       {<br>
       &nbsp;&nbsp;"512": {<br>
       &nbsp;&nbsp;&nbsp;&nbsp;"data": {},<br>
-      &nbsp;&nbsp;&nbsp;&nbsp;"points": { "center": { x: 100, y: 200 }, "topLeft": ..., ... }<br>
+      &nbsp;&nbsp;&nbsp;&nbsp;"points": { "center": { x: 100, y: 200 }, "topLeft": ..., ... },<br>
+      &nbsp;&nbsp;&nbsp;&nbsp;"picture": { ... }<br>
       &nbsp;&nbsp;}<br>
       }
     </code>
@@ -98,4 +99,18 @@
       <li><code>paperNumber</code>: paper number to do this for (default is own paper number).</li>
     </ul>
   </p>
+
+  <h3>Camera's picture of a paper</h3>
+
+  <p>
+    You can access the camera's picture of each paper.  To display a paper picture, you could write:
+  </p>
+
+  <code>
+    const papers = await paper.get('papers');<br>
+    const number = await paper.get('number');<br>
+    <br>
+    ctx.putImageData(papers[number].picture, 0, 0);<br>
+    ctx.commit();
+  </code>
 </body>


### PR DESCRIPTION
* Looking for help with handling rotated papers! It currently only handles unrotated papers.
* The camera code stores picture data for each paper in the `picture` attribute of the program's entry in localStorage. (Alongside `points` and `number`.)
* Paper programs written by users can access the picture for a program like this: `papers[paperNumber].picture`
* Paper programs written by users can display a paper picture like this: `ctx.putImageData(papers[paperNumber].picture, 0, 0)`.