### PR TITLE
Expose dots which haven't been matched to a paper as markers

### DIFF
--- a/client/camera/CameraMain.js
+++ b/client/camera/CameraMain.js
@@ -142,9 +142,10 @@ export default class CameraMain extends React.Component {
               width={this.state.pageWidth - padding * 3 - sidebarWidth}
               config={this.props.config}
               onConfigChange={this.props.onConfigChange}
-              onProcessVideo={({ programsToRender, framerate }) => {
+              onProcessVideo={({ programsToRender, markers, framerate }) => {
                 this.setState({ framerate });
                 this._programsChange(programsToRender);
+                this.props.onMarkersChange(markers);
               }}
               allowSelectingDetectedPoints={this.state.selectedColorIndex !== -1}
               onSelectColor={color => {

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -88,7 +88,7 @@ export default class CameraVideo extends React.Component {
     );
 
     try {
-      const { programsToRender, keyPoints, dataToRemember, framerate } = detectPrograms({
+      const { programsToRender, markers, keyPoints, dataToRemember, framerate } = detectPrograms({
         config: this.props.config,
         videoCapture: this._videoCapture,
         dataToRemember: this._dataToRemember,
@@ -96,7 +96,7 @@ export default class CameraVideo extends React.Component {
       });
       this._dataToRemember = dataToRemember;
       this.setState({ keyPoints });
-      this.props.onProcessVideo({ programsToRender: programsToRender, framerate });
+      this.props.onProcessVideo({ programsToRender, markers, framerate });
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
     }

--- a/client/camera/detectPrograms.js
+++ b/client/camera/detectPrograms.js
@@ -403,24 +403,33 @@ export default function detectPrograms({ config, videoCapture, dataToRemember, d
     }
   });
 
-  // all points which haven't been matched to a shape are added as markers to the paper data
+  // all points which haven't been matched to a shape are added as markers
   const markers = keyPoints
     .filter(({ matchedShape }) => !matchedShape)
     .map(({ colorIndex, avgColor, pt, size }) => {
       const { x, y } = projectPointToUnitSquare(pt, videoMat, config.knobPoints);
-      return { size, position: { x, y }, avgColor, colorIndex };
-    });
 
-  // add markers to programs
-  programsToRender.forEach(programToRender => {
-    programToRender.markers = markers;
-  });
+      const colorName = {
+        0: 'red',
+        1: 'green',
+        2: 'blue',
+        3: 'black',
+      }[colorIndex];
+
+      return {
+        size,
+        position: { x, y },
+        color: avgColor,
+        colorName,
+      };
+    });
 
   videoMat.delete();
 
   return {
     keyPoints,
     programsToRender,
+    markers,
     dataToRemember: { vectorsBetweenCorners },
     framerate: Math.round(1000 / (Date.now() - startTime)),
   };

--- a/client/camera/entry.js
+++ b/client/camera/entry.js
@@ -38,6 +38,10 @@ if (!localStorage.hasOwnProperty('paperProgramsProgramsToRender')) {
   localStorage.paperProgramsProgramsToRender = JSON.stringify([]);
 }
 
+if (!localStorage.hasOwnProperty('paperProgramsMarkers')) {
+  localStorage.paperProgramsMarkers = JSON.stringify([]);
+}
+
 const element = document.createElement('div');
 document.body.appendChild(element);
 
@@ -48,6 +52,10 @@ function render() {
       paperProgramsProgramsToRender={JSON.parse(localStorage.paperProgramsProgramsToRender)}
       onConfigChange={config => {
         localStorage.paperProgramsConfig = JSON.stringify(config);
+        render();
+      }}
+      onMarkersChange={markers => {
+        localStorage.paperProgramsMarkers = JSON.stringify(markers);
         render();
       }}
       onProgramsChange={programs => {

--- a/client/projector/Program.js
+++ b/client/projector/Program.js
@@ -123,6 +123,8 @@ export default class Program extends React.Component {
         }
       } else if (sendData.name === 'papers') {
         this._worker.postMessage({ messageId, receiveData: { object: this.props.papers } });
+      } else if (sendData.name === 'markers') {
+        this._worker.postMessage({ messageId, receiveData: { object: this.props.markers } });
       }
     } else if (command === 'set') {
       if (sendData.name === 'data') {

--- a/client/projector/ProjectorMain.js
+++ b/client/projector/ProjectorMain.js
@@ -27,6 +27,11 @@ export default class ProjectorMain extends React.Component {
           center: mult(centerPoint, multPoint),
         },
         data: this.props.dataByProgramNumber[program.number] || {},
+        markers: program.markers.map(data => {
+          const { position, size, avgColor, colorIndex } = data;
+          const scaledPosition = mult(position, multPoint);
+          return { position: scaledPosition, size, avgColor, colorIndex };
+        }),
       };
 
       programsToRenderByNumber[program.number] = program;

--- a/client/projector/ProjectorMain.js
+++ b/client/projector/ProjectorMain.js
@@ -27,14 +27,15 @@ export default class ProjectorMain extends React.Component {
           center: mult(centerPoint, multPoint),
         },
         data: this.props.dataByProgramNumber[program.number] || {},
-        markers: program.markers.map(data => {
-          const { position, size, avgColor, colorIndex } = data;
-          const scaledPosition = mult(position, multPoint);
-          return { position: scaledPosition, size, avgColor, colorIndex };
-        }),
       };
 
       programsToRenderByNumber[program.number] = program;
+    });
+
+    const markers = this.props.markers.map(data => {
+      const { position, size, color, colorName } = data;
+      const scaledPosition = mult(position, multPoint);
+      return { position: scaledPosition, size, color, colorName };
     });
 
     return (
@@ -43,6 +44,7 @@ export default class ProjectorMain extends React.Component {
           <Program
             key={`${program.number}-${program.currentCodeHash}`}
             programsToRenderByNumber={programsToRenderByNumber}
+            markers={markers}
             programNumber={program.number}
             papers={papers}
             width={width}

--- a/client/projector/entry.js
+++ b/client/projector/entry.js
@@ -9,6 +9,7 @@ function render(callback) {
   ReactDOM.render(
     <ProjectorMain
       programsToRender={JSON.parse(localStorage.paperProgramsProgramsToRender || '[]')}
+      markers={JSON.parse(localStorage.paperProgramsMarkers || '[]')}
       dataByProgramNumber={JSON.parse(localStorage.paperProgramsDataByProgramNumber || '{}')}
       onDataByProgramNumberChange={(dataByProgramNumber, otherCallback) => {
         localStorage.paperProgramsDataByProgramNumber = JSON.stringify(dataByProgramNumber);


### PR DESCRIPTION
I wanted to have markers which are tracked independently of the papers, similar to issue #42. I thought the fastest implementation would be to reuse the existing circle detection of the paper recognition. Any point which isn't part a corner shape is exposed as a marker on each paper object

```JavaScript
const papers = await paper.get('papers');
const number = await paper.get('number');

// each paper has list of markers
papers[number].markers
```

I've build a little curling game with it:

![img_20180414_204202](https://user-images.githubusercontent.com/650540/38796485-dcb98cb0-415b-11e8-9fa5-0d7f0a757acf.jpg)
https://www.youtube.com/watch?v=0wXpnWLRP1Y

The only drawback I've noticed is that if a corner of a paper is partially covered the remaining dots are no longer part of a shape and will be recognized as markers. In my demo, I've dealt with this by using bigger circles for the markers and filter for the size in my paper program. The implementation isn't complete right now; I would also like to add the information which of the markers are on the paper and their relative position to the paper. I'm interested to hear your feedback.