### PR TITLE
Expose marker data

### DIFF
--- a/client/camera/CameraMain.js
+++ b/client/camera/CameraMain.js
@@ -150,12 +150,16 @@ export default class CameraMain extends React.Component {
                 this.props.onMarkersChange(markers);
               }}
               allowSelectingDetectedPoints={this.state.selectedColorIndex !== -1}
-              onSelectColor={color => {
+              onSelectPoint={({ color, size }) => {
                 if (this.state.selectedColorIndex === -1) return;
 
                 const colorsRGB = this.props.config.colorsRGB.slice();
                 colorsRGB[this.state.selectedColorIndex] = color.map(value => Math.round(value));
-                this.props.onConfigChange({ ...this.props.config, colorsRGB });
+
+                const paperDotSizes = this.props.config.paperDotSizes.slice();
+                paperDotSizes[this.state.selectedColorIndex] = size;
+
+                this.props.onConfigChange({ ...this.props.config, colorsRGB, paperDotSizes });
                 this.setState({ selectedColorIndex: -1 });
               }}
             />

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -152,7 +152,9 @@ export default class CameraVideo extends React.Component {
                     width: point.size / this.state.videoWidth * width,
                     height: point.size / this.state.videoHeight * height,
                   }}
-                  onClick={() => this.props.onSelectColor(point.avgColor)}
+                  onClick={() => {
+                    this.props.onSelectPoint({ color: point.avgColor, size: point.size });
+                  }}
                 />
               );
             })}

--- a/client/camera/detectPrograms.js
+++ b/client/camera/detectPrograms.js
@@ -15,7 +15,6 @@ import {
   norm,
   projectPoint,
   shrinkPoints,
-  sign,
 } from '../utils';
 import { code8400 } from '../dotCodes';
 import { colorNames, cornerNames } from '../constants';
@@ -434,7 +433,7 @@ export default function detectPrograms({ config, videoCapture, dataToRemember, d
 
         let angle = Math.atan2(sideB.y, sideB.x) - Math.atan2(sideA.y, sideA.x);
 
-        if (sign(sideB.y) === -1 && sign(sideA.y) === 1) {
+        if (sideB.y < 0 && sideA.y > 0) {
           angle += 2 * Math.PI;
         }
 

--- a/client/camera/entry.js
+++ b/client/camera/entry.js
@@ -7,6 +7,7 @@ import CameraMain from './CameraMain';
 
 const defaultConfig = {
   colorsRGB: [[119, 43, 24, 255], [94, 104, 48, 255], [65, 80, 84, 255], [0, 0, 0, 255]],
+  paperDotSizes: [8, 8, 8, 8],
   knobPoints: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 1 }],
   zoomTransform: d3.zoomIdentity,
   showOverlayKeyPointCircles: true,
@@ -24,6 +25,10 @@ function sanitizeConfig(config) {
   const newConfig = { ...config };
   if (newConfig.colorsRGB.length !== defaultConfig.colorsRGB.length)
     newConfig.colorsRGB = defaultConfig.colorsRGB;
+
+  if (!newConfig.paperDotSizes) {
+    newConfig.paperDotSizes = defaultConfig.paperDotSizes;
+  }
   return newConfig;
 }
 

--- a/client/projector/ProjectorMain.js
+++ b/client/projector/ProjectorMain.js
@@ -72,11 +72,10 @@ export default class ProjectorMain extends React.Component {
       programsToRenderByNumber[program.number] = program;
     });
 
-    const markers = this.props.markers.map(data => {
-      const { position, size, color, colorName } = data;
-      const scaledPosition = mult(position, multPoint);
-      return { position: scaledPosition, size, color, colorName };
-    });
+    const markers = this.props.markers.map(data => ({
+      ...data,
+      position: mult(data.position, multPoint),
+    }));
 
     return (
       <div>

--- a/client/utils.js
+++ b/client/utils.js
@@ -34,10 +34,6 @@ export function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
-export function sign(value) {
-  return value < 0 ? -1 : value > 0 ? 1 : 0;
-}
-
 export function moveAlongVector(amount, vector) {
   const size = norm(vector);
   return { x: amount * vector.x / size, y: amount * vector.y / size };

--- a/client/utils.js
+++ b/client/utils.js
@@ -34,6 +34,10 @@ export function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
+export function sign(value) {
+  return value < 0 ? -1 : value > 0 ? 1 : 0;
+}
+
 export function moveAlongVector(amount, vector) {
   const size = norm(vector);
   return { x: amount * vector.x / size, y: amount * vector.y / size };

--- a/docs/api.md
+++ b/docs/api.md
@@ -161,12 +161,14 @@ paper.drawFromCamera(ctx, camera, papers[someNum].points, papers[myNum].points);
 
 ## Marker Points
 
-Any dot that is not detected as part of a paper's corner is exposed as a _marker_.
+When calibrating the camera the average size of the dots is stored. Dots which are significantly bigger than the paper
+dots are recognized as markers.
 
-All detected markers are exposed here:
+
+You can request a list of all detected markers like this:
 
 ```js
-const markers = paper.get('markers');
+const markers = await paper.get('markers');
 ```
 
 Each marker has the following properties:
@@ -177,18 +179,28 @@ Each marker has the following properties:
   color: [r, g, b],
   colorName,         // "red", "green", "blue" or "black"
 
-  // WIP (planned)
-  paperNumber,
-  positionOnPaper: {x, y} // position converted to coordinate system of the paper
+  // properties which are only defined if marker is placed on a paper
+
+  paperNumber, // number of the paper the marker is placed on
+  positionOnPaper: {x, y} // normalized position of marker relative to paper origin
 }
 ```
 
-Also, each paper will know all the markers found inside its borders (WIP):
+### Working with local position
 
-```js
-const number = await paper.get('number');
-const papers = await paper.get('papers');
+The property `positionOnPaper` has a value range from 0 to 1. The top left corner has the coordinate (x = 0, y = 0) and
+the bottom right corner has the coordinate (x = 1, y = 1). If you want to get the position of a marker on the local
+canvas you have to multiply the x position with the width of the canvas and the y position with the height of the canvas.
 
-// WIP (planned)
-const markers = papers[number].markers;
+```
+var x = canvas.width * marker.positionOnPaper.x
+var y = canvas.height * marker.positionOnPaper.y
+```
+
+### Get markers of paper
+
+```
+const paperNumber = await paper.get('number')
+const markers = await paper.get('markers')
+const markersOnPaper = markers.filter(marker => marker.paperNumber === paperNumber)
 ```


### PR DESCRIPTION
This pull request changes two things:

- Adds `paperNumber` property to markers
- Paper Programs detects the markers by size and not by the fact that they are not part of a shape. When the user calibrates the colors of the markers, Paper Programs stores the size of the markers as well. Dots which are significantly larger than the paper dots are recognized as markers. It's no longer necessary to filter the markers for size in the paper program to get the real markers.

I haven't implemented the local position conversion, because I realized that it's possible that a paper has multiple canvases with different sizes. I think it's better to have a utility function to convert global coordinates to local coordinates. I want to wait until #44 is merged which restructures `paper.js` to allow imports.