### PR TITLE
Adjust sidebar layout and space URL changing UI

### DIFF
--- a/client/camera/CameraMain.css
+++ b/client/camera/CameraMain.css
@@ -31,13 +31,19 @@
 :local(.sidebar) {
   flex: 1 1 cameraMainSidebarWidth;
   color: white;
-  font: 20px sans-serif;
+  font: 18px sans-serif;
   font-weight: 300;
 }
 
 :local(.sidebarSection) {
   margin-bottom: cameraMainPadding;
   word-break: break-all;
+}
+
+:local(.sidebar) a,
+:local(.sidebar) a:hover,
+:local(.sidebar) a:visited {
+  color: rgb(50, 50, 255);
 }
 
 :local(.sidebarSectionSection) {
@@ -89,4 +95,14 @@
 }
 :local(.colorListItemSelected):hover {
   box-shadow: 0 0 0 3px white, 0 0 0 20px rgba(255, 255, 255, 0.3) inset;
+}
+
+:local(.spaceUrl) {
+  color: gray;
+  margin-bottom: calc(cameraMainPadding / 4);
+}
+
+:local(.spaceNameInput) {
+  width: 100%;
+  margin-bottom: calc(cameraMainPadding / 4);
 }

--- a/client/camera/CameraMain.js
+++ b/client/camera/CameraMain.js
@@ -19,6 +19,8 @@ export default class CameraMain extends React.Component {
       selectedColorIndex: -1,
       spaceData: { programs: [] },
       autoPrintedNumbers: [],
+      isEditingSpaceUrl: false,
+      spaceUrlSwitcherValue: props.config.spaceUrl,
     };
   }
 
@@ -165,200 +167,225 @@ export default class CameraMain extends React.Component {
             />
           </div>
           <div className={styles.sidebar}>
-            <div className={styles.sidebarSection}>
-              space url{' '}
-              <input
-                value={this.props.config.spaceUrl}
-                onChange={event =>
-                  this.props.onConfigChange({ ...this.props.config, spaceUrl: event.target.value })
-                }
-              />
-            </div>
+            <div>
+              <div className={styles.sidebarSection}>
+                <div className={styles.sidebarSectionSection}>editor url</div>
+                <a href={editorUrl} target="_blank">
+                  {editorUrl}
+                </a>
+              </div>
 
-            <div className={styles.sidebarSection}>
-              editor:
-              <a href={editorUrl} target="_blank">
-                {editorUrl}
-              </a>
-            </div>
+              <div className={styles.sidebarSection}>
+                framerate <strong>{this.state.framerate}</strong>
+              </div>
 
-            <div className={styles.sidebarSection}>
-              framerate <strong>{this.state.framerate}</strong>
-            </div>
+              <div className={styles.sidebarSection}>
+                <div className={styles.sidebarSectionSection}>print queue</div>
+                <div>
+                  {this.state.spaceData.programs
+                    .filter(program => !program.printed || this.props.config.showPrintedInQueue)
+                    .map(program => (
+                      <div
+                        key={program.number}
+                        className={
+                          program.printed
+                            ? styles.printQueueItemPrinted
+                            : styles.printQueueItemNotPrinted
+                        }
+                        onClick={() => this._print(program)}
+                      >
+                        <strong>#{program.number}</strong> {codeToName(program.originalCode)}{' '}
+                        {!program.printed && (
+                          <span
+                            className={styles.printQueueItemDone}
+                            onClick={event => {
+                              event.stopPropagation();
+                              this._markPrinted(program);
+                            }}
+                          >
+                            [done]
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                </div>
+                <button onClick={this._printCalibration}>print calibration page</button>{' '}
+                <button onClick={this._createHelloWorld}>create hello world program</button>
+                <div>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.autoPrintEnabled}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        autoPrintEnabled: !this.props.config.autoPrintEnabled,
+                      })
+                    }
+                  />{' '}
+                  auto-print (start Chrome with "--kiosk-printing" flag)
+                </div>
+                <div>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.showPrintedInQueue}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        showPrintedInQueue: !this.props.config.showPrintedInQueue,
+                      })
+                    }
+                  />{' '}
+                  show printed in queue
+                </div>
+              </div>
 
-            <div className={styles.sidebarSection}>
-              <div className={styles.sidebarSectionSection}>print queue</div>
-              <div>
-                {this.state.spaceData.programs
-                  .filter(program => !program.printed || this.props.config.showPrintedInQueue)
-                  .map(program => (
+              <div className={styles.sidebarSection}>
+                <div className={styles.sidebarSectionSection}>colors</div>
+                <div>
+                  {this.props.config.colorsRGB.map((color, colorIndex) => (
                     <div
-                      key={program.number}
-                      className={
-                        program.printed
-                          ? styles.printQueueItemPrinted
-                          : styles.printQueueItemNotPrinted
+                      key={colorIndex}
+                      className={[
+                        styles.colorListItem,
+                        this.state.selectedColorIndex === colorIndex &&
+                          styles.colorListItemSelected,
+                      ].join(' ')}
+                      style={{ background: `rgb(${color.slice(0, 3).join(',')})` }}
+                      onClick={() =>
+                        this.setState(state => ({
+                          selectedColorIndex:
+                            state.selectedColorIndex === colorIndex ? -1 : colorIndex,
+                        }))
                       }
-                      onClick={() => this._print(program)}
                     >
-                      <strong>#{program.number}</strong> {codeToName(program.originalCode)}{' '}
-                      {!program.printed && (
-                        <span
-                          className={styles.printQueueItemDone}
-                          onClick={event => {
-                            event.stopPropagation();
-                            this._markPrinted(program);
-                          }}
-                        >
-                          [done]
-                        </span>
-                      )}
+                      <strong>{colorNames[colorIndex]}</strong>
                     </div>
                   ))}
+                </div>
               </div>
-              <button onClick={this._printCalibration}>print calibration page</button>{' '}
-              <button onClick={this._createHelloWorld}>create hello world program</button>
-              <div>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.autoPrintEnabled}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      autoPrintEnabled: !this.props.config.autoPrintEnabled,
-                    })
-                  }
-                />{' '}
-                auto-print (start Chrome with "--kiosk-printing" flag)
-              </div>
-              <div>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.showPrintedInQueue}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      showPrintedInQueue: !this.props.config.showPrintedInQueue,
-                    })
-                  }
-                />{' '}
-                show printed in queue
-              </div>
-            </div>
 
-            <div className={styles.sidebarSection}>
-              <div className={styles.sidebarSectionSection}>colors</div>
-              <div>
-                {this.props.config.colorsRGB.map((color, colorIndex) => (
-                  <div
-                    key={colorIndex}
-                    className={[
-                      styles.colorListItem,
-                      this.state.selectedColorIndex === colorIndex && styles.colorListItemSelected,
-                    ].join(' ')}
-                    style={{ background: `rgb(${color.slice(0, 3).join(',')})` }}
-                    onClick={() =>
-                      this.setState(state => ({
-                        selectedColorIndex:
-                          state.selectedColorIndex === colorIndex ? -1 : colorIndex,
-                      }))
+              <div className={styles.sidebarSection}>
+                <div className={styles.sidebarSectionSection}>show overlay</div>
+
+                <div className={styles.sidebarSectionSection}>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.showOverlayKeyPointCircles}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        showOverlayKeyPointCircles: !this.props.config.showOverlayKeyPointCircles,
+                      })
                     }
-                  >
-                    <strong>{colorNames[colorIndex]}</strong>
+                  />{' '}
+                  keypoint circles
+                </div>
+
+                <div className={styles.sidebarSectionSection}>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.showOverlayKeyPointText}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        showOverlayKeyPointText: !this.props.config.showOverlayKeyPointText,
+                      })
+                    }
+                  />{' '}
+                  keypoint text
+                </div>
+
+                <div className={styles.sidebarSectionSection}>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.showOverlayComponentLines}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        showOverlayComponentLines: !this.props.config.showOverlayComponentLines,
+                      })
+                    }
+                  />{' '}
+                  component lines
+                </div>
+
+                <div className={styles.sidebarSectionSection}>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.showOverlayShapeId}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        showOverlayShapeId: !this.props.config.showOverlayShapeId,
+                      })
+                    }
+                  />{' '}
+                  shape ids
+                </div>
+
+                <div className={styles.sidebarSectionSection}>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.showOverlayProgram}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        showOverlayProgram: !this.props.config.showOverlayProgram,
+                      })
+                    }
+                  />{' '}
+                  programs
+                </div>
+              </div>
+
+              <div className={styles.sidebarSection}>
+                <div className={styles.sidebarSectionSection}>debugging</div>
+                <div className={styles.sidebarSectionSection}>
+                  <input
+                    type="checkbox"
+                    checked={this.props.config.freezeDetection}
+                    onChange={() =>
+                      this.props.onConfigChange({
+                        ...this.props.config,
+                        freezeDetection: !this.props.config.freezeDetection,
+                      })
+                    }
+                  />{' '}
+                  freeze detection
+                </div>
+              </div>
+            </div>
+            <div className={styles.sidebarSection}>
+              <div className={styles.sidebarSectionSection}>space url </div>
+              {!this.state.isEditingSpaceUrl ? (
+                <div>
+                  <div className={styles.spaceUrl}>{this.props.config.spaceUrl}</div>
+                  <button onClick={() => this.setState({ isEditingSpaceUrl: true })}>
+                    change space
+                  </button>
+                </div>
+              ) : (
+                <div>
+                  <input
+                    className={styles.spaceNameInput}
+                    value={this.state.spaceUrlSwitcherValue}
+                    onChange={event => this.setState({ spaceUrlSwitcherValue: event.target.value })}
+                  />
+                  <div>
+                    <button
+                      onClick={() => {
+                        this.props.onConfigChange({
+                          ...this.props.config,
+                          spaceUrl: this.state.spaceUrlSwitcherValue,
+                        });
+                        this.setState({ isEditingSpaceUrl: false });
+                      }}
+                    >
+                      switch to new url
+                    </button>
                   </div>
-                ))}
-              </div>
-            </div>
-
-            <div className={styles.sidebarSection}>
-              <div className={styles.sidebarSectionSection}>show overlay</div>
-
-              <div className={styles.sidebarSectionSection}>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.showOverlayKeyPointCircles}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      showOverlayKeyPointCircles: !this.props.config.showOverlayKeyPointCircles,
-                    })
-                  }
-                />{' '}
-                keypoint circles
-              </div>
-
-              <div className={styles.sidebarSectionSection}>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.showOverlayKeyPointText}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      showOverlayKeyPointText: !this.props.config.showOverlayKeyPointText,
-                    })
-                  }
-                />{' '}
-                keypoint text
-              </div>
-
-              <div className={styles.sidebarSectionSection}>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.showOverlayComponentLines}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      showOverlayComponentLines: !this.props.config.showOverlayComponentLines,
-                    })
-                  }
-                />{' '}
-                component lines
-              </div>
-
-              <div className={styles.sidebarSectionSection}>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.showOverlayShapeId}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      showOverlayShapeId: !this.props.config.showOverlayShapeId,
-                    })
-                  }
-                />{' '}
-                shape ids
-              </div>
-
-              <div className={styles.sidebarSectionSection}>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.showOverlayProgram}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      showOverlayProgram: !this.props.config.showOverlayProgram,
-                    })
-                  }
-                />{' '}
-                programs
-              </div>
-            </div>
-
-            <div className={styles.sidebarSection}>
-              <div className={styles.sidebarSectionSection}>debugging</div>
-              <div className={styles.sidebarSectionSection}>
-                <input
-                  type="checkbox"
-                  checked={this.props.config.freezeDetection}
-                  onChange={() =>
-                    this.props.onConfigChange({
-                      ...this.props.config,
-                      freezeDetection: !this.props.config.freezeDetection,
-                    })
-                  }
-                />{' '}
-                freeze detection
-              </div>
+                </div>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
<img width="335" alt="screen shot 2018-05-09 at 12 06 21" src="https://user-images.githubusercontent.com/579491/39809196-6d8a69d0-5381-11e8-9f68-a80d09f9c7bd.png">

- Bumps the font size of the sidebar down from 20px to 18px
- Makes the editor URL a slightly more visible shade of blue
- Moves the space URL section of the sidebar down to the bottom of the sidbar, and changes it from a text input UI to one that makes the changing of the space URL value very explicit (as sketched [here](https://github.com/janpaul123/paperprograms/issues/34#issuecomment-385371399)

Didn't get fancy with the layout as doing so clashed with the camera's current spartan aesthetic. 😄 

Closes #34  