### PR TITLE
Make db for development and docker configurable with env variable

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -3,11 +3,11 @@ require('dotenv').config();
 module.exports = {
   development: {
     client: 'pg',
-    connection: 'postgres://localhost/paper_programs_development',
+    connection: process.env.DATABASE_URL || 'postgres://localhost/paper_programs_development',
   },
   docker: {
     client: 'pg',
-    connection: 'postgres://root@postgres/paper_programs_development',
+    connection: process.env.DATABASE_URL || 'postgres://root@postgres/paper_programs_development',
   },
   production: {
     client: 'pg',


### PR DESCRIPTION
It would be nice to make the connection url for development and docker configurable as well. Before we had 2 databases for development and production. This had the disadvantage, that when you switch to development all the papers in production stop working. Reading the connection url from the environment variables and using the default local db as a fallback would allow us to use any db in development without breaking the current setup.