### PR TITLE
Multiple whiskers

### DIFF
--- a/client/paper/entry.js
+++ b/client/paper/entry.js
@@ -1,7 +1,7 @@
 import Matrix from 'node-matrices';
 import { projectPoint } from '../utils';
 import { fillQuadTex, fillTriTex } from './canvasUtils';
-import WhiskerFactory from './whisker';
+import Whisker from './whisker';
 
 (function(workerContext) {
   if (workerContext.paper) return;
@@ -12,15 +12,13 @@ import WhiskerFactory from './whisker';
     messageCallbacks[event.data.messageId](event.data.receiveData);
   });
 
-  const whiskerFactory = new WhiskerFactory(workerContext);
-
   workerContext.paper = {
     get(name, data, callback) {
       if (name === 'whisker') {
-        const whisker = whiskerFactory.createWhisker(data);
+        const whisker = new Whisker(data);
 
         if (callback) {
-          whisker.then(callback);
+          callback(whisker);
           return;
         }
         return whisker;
@@ -136,104 +134,20 @@ import WhiskerFactory from './whisker';
     callback,
     whiskerPointCallback,
   } = {}) => {
-    // eslint-disable-next-line no-console
-    console.warn('paper.whenPointsAt is deprecated, use the new whisker api instead');
+    const whisker = new Whisker({
+      direction,
+      whiskerLength,
+      paperNumber,
+      requiredData,
+    });
 
-    whiskerLength = whiskerLength || 0.7;
-    paperNumber = paperNumber || (await workerContext.paper.get('number'));
-    requiredData = requiredData || [];
-    const supporterCanvas = await workerContext.paper.get('supporterCanvas', { id: 'whisker' });
-    const supporterCtx = supporterCanvas.getContext('2d');
-    let pointAtData = null;
-    let lastWhiskerEnd = null;
-
-    // Adapted from https://stackoverflow.com/questions/9043805/test-if-two-lines-intersect-javascript-function
-    function intersects(v1, v2, v3, v4) {
-      const det = (v2.x - v1.x) * (v4.y - v3.y) - (v4.x - v3.x) * (v2.y - v1.y);
-      if (det === 0) {
-        return false;
-      } else {
-        const lambda = ((v4.y - v3.y) * (v4.x - v1.x) + (v3.x - v4.x) * (v4.y - v1.y)) / det;
-        const gamma = ((v1.y - v2.y) * (v4.x - v1.x) + (v2.x - v1.x) * (v4.y - v1.y)) / det;
-        return 0 < lambda && lambda < 1 && (0 < gamma && gamma < 1);
-      }
-    }
-    function intersectsPaper(whiskerStart, whiskerEnd, paper) {
-      return (
-        (intersects(whiskerStart, whiskerEnd, paper.points.topLeft, paper.points.topRight) ||
-          intersects(whiskerStart, whiskerEnd, paper.points.topRight, paper.points.bottomRight) ||
-          intersects(whiskerStart, whiskerEnd, paper.points.bottomRight, paper.points.bottomLeft) ||
-          intersects(whiskerStart, whiskerEnd, paper.points.bottomLeft, paper.points.topLeft)) &&
-        requiredData.every(name => paper.data[name] !== undefined)
-      );
+    if (callback) {
+      whisker.on('paperAdded', callback);
+      whisker.on('paperRemoved', () => callback(null));
     }
 
-    setInterval(async () => {
-      const papers = await workerContext.paper.get('papers');
-      const points = papers[paperNumber].points;
-
-      let segment = [points.topLeft, points.topRight];
-      if (direction === 'right') segment = [points.topRight, points.bottomRight];
-      if (direction === 'down') segment = [points.bottomRight, points.bottomLeft];
-      if (direction === 'left') segment = [points.bottomLeft, points.topLeft];
-
-      const whiskerStart = {
-        x: (segment[0].x + segment[1].x) / 2,
-        y: (segment[0].y + segment[1].y) / 2,
-      };
-      const whiskerEnd = {
-        x: whiskerStart.x + (segment[1].y - segment[0].y) * whiskerLength,
-        y: whiskerStart.y - (segment[1].x - segment[0].x) * whiskerLength,
-      };
-
-      if (
-        !pointAtData ||
-        !papers[pointAtData.paperNumber] ||
-        // Try keeping `pointAtData` stable if possible.
-        !intersectsPaper(whiskerStart, whiskerEnd, papers[pointAtData.paperNumber])
-      ) {
-        let newPointAtData = null;
-        Object.keys(papers).forEach(otherPaperNumber => {
-          if (otherPaperNumber === paperNumber) return;
-          if (intersectsPaper(whiskerStart, whiskerEnd, papers[otherPaperNumber])) {
-            newPointAtData = { paperNumber: otherPaperNumber, paper: papers[otherPaperNumber] };
-          }
-        });
-        if (newPointAtData !== pointAtData) {
-          pointAtData = newPointAtData;
-          if (callback) callback(pointAtData);
-        }
-      }
-
-      supporterCtx.clearRect(0, 0, supporterCanvas.width, supporterCanvas.height);
-      supporterCtx.fillStyle = supporterCtx.strokeStyle = pointAtData
-        ? 'rgb(0, 255, 0)'
-        : 'rgb(255, 0, 0)';
-      supporterCtx.beginPath();
-      supporterCtx.moveTo(whiskerStart.x, whiskerStart.y);
-      supporterCtx.lineTo(whiskerEnd.x, whiskerEnd.y);
-      supporterCtx.stroke();
-
-      const dotFraction = (Date.now() / 600) % 1;
-      supporterCtx.beginPath();
-      supporterCtx.arc(
-        whiskerEnd.x * dotFraction + whiskerStart.x * (1 - dotFraction),
-        whiskerEnd.y * dotFraction + whiskerStart.y * (1 - dotFraction),
-        2,
-        0,
-        2 * Math.PI
-      );
-      supporterCtx.fill();
-      supporterCtx.commit();
-
-      if (
-        !lastWhiskerEnd ||
-        lastWhiskerEnd.x !== whiskerEnd.x ||
-        lastWhiskerEnd.y !== whiskerEnd.y
-      ) {
-        lastWhiskerEnd = whiskerEnd;
-        if (whiskerPointCallback) whiskerPointCallback(whiskerEnd.x, whiskerEnd.y);
-      }
-    }, 10);
+    if (whiskerPointCallback) {
+      whisker.on('whiskerMoved', whiskerPointCallback);
+    }
   };
 })(self);

--- a/client/paper/whisker.js
+++ b/client/paper/whisker.js
@@ -118,7 +118,7 @@ class Whisker extends EventEmitter {
     ctx.lineTo(whiskerEnd.x, whiskerEnd.y);
     ctx.stroke();
 
-    const dotFraction = Math.abs(Math.sin((Date.now() / 600)));
+    const dotFraction = Math.abs(Math.sin(Date.now() / 600));
 
     // only show dot when whisker is connected to other paper
     if (this._pointAtData) {

--- a/client/paper/whisker.js
+++ b/client/paper/whisker.js
@@ -53,6 +53,7 @@ class Whisker extends EventEmitter {
     direction = 'up',
     whiskerLength = 0.7,
     requiredData = [],
+    color = 'rgb(255, 0, 0)',
   }) {
     super();
 
@@ -60,6 +61,7 @@ class Whisker extends EventEmitter {
     this.direction = direction;
     this.whiskerLength = whiskerLength;
     this.requiredData = requiredData;
+    this.color = color;
 
     this._pointAtData = null;
     this._lastWhiskerEnd = null;
@@ -108,24 +110,28 @@ class Whisker extends EventEmitter {
       this._pointAtData = newPointAtData;
     }
 
-    // render line
+    // render whisker with dot animation
     ctx.clearRect(0, 0, ctx.width, ctx.height);
-    ctx.fillStyle = ctx.strokeStyle = this._pointAtData ? 'rgb(0, 255, 0)' : 'rgb(255, 0, 0)';
+    ctx.fillStyle = ctx.strokeStyle = this.color;
     ctx.beginPath();
     ctx.moveTo(whiskerStart.x, whiskerStart.y);
     ctx.lineTo(whiskerEnd.x, whiskerEnd.y);
     ctx.stroke();
 
-    const dotFraction = (Date.now() / 600) % 1;
-    ctx.beginPath();
-    ctx.arc(
-      whiskerEnd.x * dotFraction + whiskerStart.x * (1 - dotFraction),
-      whiskerEnd.y * dotFraction + whiskerStart.y * (1 - dotFraction),
-      2,
-      0,
-      2 * Math.PI
-    );
-    ctx.fill();
+    const dotFraction = Math.abs(Math.sin((Date.now() / 600)));
+
+    // only show dot when whisker is connected to other paper
+    if (this._pointAtData) {
+      ctx.beginPath();
+      ctx.arc(
+        whiskerEnd.x * dotFraction + whiskerStart.x * (1 - dotFraction),
+        whiskerEnd.y * dotFraction + whiskerStart.y * (1 - dotFraction),
+        2,
+        0,
+        2 * Math.PI
+      );
+      ctx.fill();
+    }
 
     if (
       !this._lastWhiskerEnd ||

--- a/client/paper/whisker.js
+++ b/client/paper/whisker.js
@@ -1,0 +1,165 @@
+import EventEmitter from 'events';
+
+export default class WhiskerFactory {
+  constructor(workerContext) {
+    this.whiskers = [];
+    this.workerContext = workerContext;
+    this.update = this.update.bind(this);
+  }
+
+  async createWhisker(options) {
+    const whisker = new Whisker({
+      ...options,
+      paperNumber: options.paperNumber || (await this.workerContext.paper.get('number')),
+      workerContext: this.workerContext,
+      whiskerFactory: this,
+    });
+
+    if (this.whiskers.length === 0) {
+      setInterval(this.update, 10);
+    }
+
+    if (!this.canvas) {
+      this.canvas = await this.workerContext.paper.get('supporterCanvas', { id: 'whisker' });
+      this.ctx = this.canvas.getContext('2d');
+    }
+
+    this.whiskers.push(whisker);
+
+    return whisker;
+  }
+
+  async destroyWhisker(whisker) {
+    this.whiskers = this.whiskers.filter(other => other !== whisker);
+
+    if (this.whiskers.length === 0) {
+      clearInterval(this.update);
+    }
+  }
+
+  async update() {
+    const papers = await this.workerContext.paper.get('papers');
+
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.whiskers.forEach(whisker => whisker.update(papers, this.ctx));
+    this.ctx.commit();
+  }
+}
+
+class Whisker extends EventEmitter {
+  constructor({
+    whiskerFactory,
+    paperNumber,
+    direction = 'up',
+    whiskerLength = 0.7,
+    requiredData = [],
+  }) {
+    super();
+
+    this.paperNumber = paperNumber;
+    this.direction = direction;
+    this.whiskerLength = whiskerLength;
+    this.requiredData = requiredData;
+
+    this._pointAtData = null;
+    this._lastWhiskerEnd = null;
+    this._whiskerFactory = whiskerFactory;
+  }
+
+  update(papers, ctx) {
+    const points = papers[this.paperNumber].points;
+
+    let segment = [points.topLeft, points.topRight];
+    if (this.direction === 'right') segment = [points.topRight, points.bottomRight];
+    if (this.direction === 'down') segment = [points.bottomRight, points.bottomLeft];
+    if (this.direction === 'left') segment = [points.bottomLeft, points.topLeft];
+
+    const whiskerStart = {
+      x: (segment[0].x + segment[1].x) / 2,
+      y: (segment[0].y + segment[1].y) / 2,
+    };
+    const whiskerEnd = {
+      x: whiskerStart.x + (segment[1].y - segment[0].y) * this.whiskerLength,
+      y: whiskerStart.y - (segment[1].x - segment[0].x) * this.whiskerLength,
+    };
+
+    if (
+      !this._pointAtData ||
+      !papers[this._pointAtData.paperNumber] ||
+      // Try keeping `pointAtData` stable if possible.
+      !this._intersectsPaper(whiskerStart, whiskerEnd, papers[this._pointAtData.paperNumber])
+    ) {
+      let newPointAtData = null;
+      Object.keys(papers).forEach(otherPaperNumber => {
+        if (otherPaperNumber === this.paperNumber) return;
+        if (this._intersectsPaper(whiskerStart, whiskerEnd, papers[otherPaperNumber])) {
+          newPointAtData = { paperNumber: otherPaperNumber, paper: papers[otherPaperNumber] };
+        }
+      });
+
+      if (this._pointAtData) {
+        this.emit('paperRemoved', this._pointAtData);
+      }
+
+      if (newPointAtData) {
+        this.emit('paperAdded', newPointAtData);
+      }
+
+      this._pointAtData = newPointAtData;
+    }
+
+    // render line
+    ctx.clearRect(0, 0, ctx.width, ctx.height);
+    ctx.fillStyle = ctx.strokeStyle = this._pointAtData ? 'rgb(0, 255, 0)' : 'rgb(255, 0, 0)';
+    ctx.beginPath();
+    ctx.moveTo(whiskerStart.x, whiskerStart.y);
+    ctx.lineTo(whiskerEnd.x, whiskerEnd.y);
+    ctx.stroke();
+
+    const dotFraction = (Date.now() / 600) % 1;
+    ctx.beginPath();
+    ctx.arc(
+      whiskerEnd.x * dotFraction + whiskerStart.x * (1 - dotFraction),
+      whiskerEnd.y * dotFraction + whiskerStart.y * (1 - dotFraction),
+      2,
+      0,
+      2 * Math.PI
+    );
+    ctx.fill();
+
+    if (
+      !this._lastWhiskerEnd ||
+      this._lastWhiskerEnd.x !== whiskerEnd.x ||
+      this._lastWhiskerEnd.y !== whiskerEnd.y
+    ) {
+      this._lastWhiskerEnd = whiskerEnd;
+      this.emit('whiskerMoved', { x: Math.round(whiskerEnd.x), y: Math.round(whiskerEnd.y) });
+    }
+  }
+
+  _intersectsPaper(whiskerStart, whiskerEnd, paper) {
+    return (
+      (intersects(whiskerStart, whiskerEnd, paper.points.topLeft, paper.points.topRight) ||
+        intersects(whiskerStart, whiskerEnd, paper.points.topRight, paper.points.bottomRight) ||
+        intersects(whiskerStart, whiskerEnd, paper.points.bottomRight, paper.points.bottomLeft) ||
+        intersects(whiskerStart, whiskerEnd, paper.points.bottomLeft, paper.points.topLeft)) &&
+      this.requiredData.every(name => paper.data[name] !== undefined)
+    );
+  }
+
+  destroy() {
+    this._whiskerFactory.destroyWhisker(this);
+  }
+}
+
+// Adapted from https://stackoverflow.com/questions/9043805/test-if-two-lines-intersect-javascript-function
+function intersects(v1, v2, v3, v4) {
+  const det = (v2.x - v1.x) * (v4.y - v3.y) - (v4.x - v3.x) * (v2.y - v1.y);
+  if (det === 0) {
+    return false;
+  } else {
+    const lambda = ((v4.y - v3.y) * (v4.x - v1.x) + (v3.x - v4.x) * (v4.y - v1.y)) / det;
+    const gamma = ((v1.y - v2.y) * (v4.x - v1.x) + (v2.x - v1.x) * (v4.y - v1.y)) / det;
+    return 0 < lambda && lambda < 1 && (0 < gamma && gamma < 1);
+  }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,22 +180,6 @@ If you don't need a whisker any more you can remove it:
 whisker.destroy()
 ```
 
-*deprecated* old api:
-
-```js
-paper.whenPointsAt({
-  callback: ({paperNumber, paper}) => {
-    /* do something */
-  },
-
-  // optional
-  direction,      // "up" (default), "down", "left", "right"
-  whiskerLength,  // as fraction of the side (default 0.7)
-  requiredData,   // array of data fields that must be present in the other paper
-  paperNumber,    // paper number to do this for (default is own paper number)
-});
-```
-
 ## Camera Access
 
 You can draw a region of the camera picture to another destination region (using arbitrary quadrilaterals).

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,9 +133,58 @@ await paper.set('iframe', { src: 'http://www.example.com' });
 
 A paper can be given a "whisker" that lets you know when it touches another paper:
 
+
+```js
+const whisker = await paper.get('whisker', {direction: 'up'})
+```
+
+You can react to different events with a whisker
+
+```js
+whisker.on('paperAdded', ({paperNumber, paper}) => {
+  console.log('added paper', paperNumber)
+})
+
+whisker.on('paperRemoved', ({paperNumber, paper}) => {
+  console.log('removed paper', paperNumber)
+})
+
+whisker.on('movedWhisker', ({ x, y }) => {
+  console.log('whisker tip x : ' + x + ' y: ' + y);
+})
+```
+
+You can customize a whisker:
+
+```js
+const whisker = paper.get('whisker', {
+  direction,      // "up" (default), "down", "left", "right"
+  whiskerLength,  // as fraction of the side (default 0.7)
+  requiredData,   // array of data fields that must be present in the other paper
+  paperNumber,    // paper number to do this for (default is own paper number)
+  color,          // color of the whisker (default "rgb(255, 0, 0)")
+})
+```
+
+You can also change these attributes after the whisker was created:
+
+```js
+whisker.direction = "down"
+whisker.color = "green"
+```
+
+
+If you don't need a whisker any more you can remove it:
+
+```js
+whisker.destroy()
+```
+
+*deprecated* old api:
+
 ```js
 paper.whenPointsAt({
-  callback: ({paperNumber, paperObj}) => {
+  callback: ({paperNumber, paper}) => {
     /* do something */
   },
 


### PR DESCRIPTION
## Summary API Changes 

as discussed in original issue: #49 

### Creation / Removal of whiskers
Currently, the API is missing a way to remove whiskers again. I would like to add a whisker only if the paper has something connected to the output. The program can change audio nodes dynamically so it should be possible to remove whiskers again if there is no longer anything connected to the sound output.

```js
var whisker = await paper.get('whisker', {
  direction,      // "up" (default), "down", "left", "right"
  whiskerLength,  // as fraction of the side (default 0.7)
  requiredData,   // array of data fields that must be present in the other paper
  paperNumber,    // paper number to do this for (default is own paper number)
});

// destroy
whisker.destroy();
```

### Different whisker color
If a paper has multiple whiskers it would be nice if you could change the color of the whisker to differentiate them better. Instead of a color change the "connected" state is indicated by the moving dot animation. If the paper is not connected a static line is rendered without the moving dot.
```js
var whisker = await paper.get('whisker', {
  direction: "up",
  color: "blue", // new color attribute (default: red)
  requiredData: [ "frequency" ]
});
```

### Separate event handlers for placement and removal of papers
I think it would be cleaner to have two separate events for when a paper is placed and when it's removed. This makes it easier to explain the API. It's not necessary to check for null and in the removed paper event handler we can also pass in the information about the paper which was removed.

```js
whisker.on("paperAdded" ({paperNumber, paperObj}) => { /* do something */ })
whisker.on("paperRemoved", ({paperNumber, paperObj}) => { /* do something */})
```