### PR TITLE
2-3x speed up to blob detection

### DIFF
--- a/client/camera/CameraMain.js
+++ b/client/camera/CameraMain.js
@@ -142,6 +142,7 @@ export default class CameraMain extends React.Component {
         </div>
         <div className={styles.appRoot}>
           <div className={styles.video}>
+
             <CameraVideo
               width={this.state.pageWidth - padding * 3 - sidebarWidth}
               config={this.props.config}
@@ -176,7 +177,25 @@ export default class CameraMain extends React.Component {
               </div>
 
               <div className={styles.sidebarSection}>
-                framerate <strong>{this.state.framerate}</strong>
+                <span>Accuracy</span>
+                <input
+                  name="scaleFactor"
+                  type="range"
+                  min="1"
+                  max="10"
+                  step="1"
+                  value={this.props.config.scaleFactor}
+                  onChange={event => {
+                    this.props.onConfigChange({
+                      ...this.props.config,
+                      scaleFactor: event.target.valueAsNumber,
+                    });
+                  }}
+                />
+                <span>Performance</span>
+                <div>
+                  framerate <strong>{this.state.framerate}</strong>
+                </div>
               </div>
 
               <div className={styles.sidebarSection}>

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -80,6 +80,7 @@ export default class CameraVideo extends React.Component {
         videoCapture: this._videoCapture,
         dataToRemember: this._dataToRemember,
         displayMat,
+        scaleFactor: this.props.config.scaleFactor,
       });
       this._dataToRemember = dataToRemember;
       this.setState({ keyPoints });

--- a/client/camera/detectPrograms.js
+++ b/client/camera/detectPrograms.js
@@ -152,7 +152,13 @@ function colorIndexesForShape(shape, keyPoints, videoMat, colorsRGB) {
   return shapeColors.map(color => colorIndexForColor(color, closestColors));
 }
 
-export default function detectPrograms({ config, videoCapture, dataToRemember, displayMat }) {
+export default function detectPrograms({
+  config,
+  videoCapture,
+  dataToRemember,
+  displayMat,
+  scaleFactor,
+}) {
   const startTime = Date.now();
   const paperDotSizes = config.paperDotSizes;
   const paperDotSizeVariance = // difference min/max size * 2
@@ -183,6 +189,7 @@ export default function detectPrograms({ config, videoCapture, dataToRemember, d
     minArea: 25,
     filterByInertia: false,
     faster: true,
+    scaleFactor,
   });
 
   clippedVideoMat.delete();

--- a/client/camera/entry.js
+++ b/client/camera/entry.js
@@ -19,6 +19,7 @@ const defaultConfig = {
   autoPrintEnabled: false,
   freezeDetection: false,
   showPrintedInQueue: false,
+  scaleFactor: 4,
 };
 
 function sanitizeConfig(config) {


### PR DESCRIPTION
added scaleFactor simpleBlobDetection. Downscales the image before converting
to grayscale and looking for blobs.

Speed up amount depends on your webcam resolution and chosen parameters.

I have things pretty good with a 4x scale, and changing threshold step to 20. 

It could be made more user friendly by always scaling to a particular size (e.g. width of 300) regardless of resolution, but this also takes away the control that the parameter offers.