### PR TITLE
camera: add threshold override

### DIFF
--- a/client/camera/CameraMain.js
+++ b/client/camera/CameraMain.js
@@ -73,10 +73,8 @@ export default class CameraMain extends React.Component {
       { json: { printed } },
       (error, response) => {
         if (error) {
-          console.log('this');
           console.error(error); // eslint-disable-line no-console
         } else {
-          console.log('that');
           this.setState({ spaceData: response.body });
         }
       }

--- a/client/camera/CameraVideo.js
+++ b/client/camera/CameraVideo.js
@@ -81,6 +81,7 @@ export default class CameraVideo extends React.Component {
         dataToRemember: this._dataToRemember,
         displayMat,
         scaleFactor: this.props.config.scaleFactor,
+        allBlobsAreKeyPoints: this.props.allowSelectingDetectedPoints,
       });
       this._dataToRemember = dataToRemember;
       this.setState({ keyPoints });

--- a/client/camera/detectPrograms.js
+++ b/client/camera/detectPrograms.js
@@ -158,12 +158,14 @@ export default function detectPrograms({
   dataToRemember,
   displayMat,
   scaleFactor,
+  allBlobsAreKeyPoints,
 }) {
   const startTime = Date.now();
   const paperDotSizes = config.paperDotSizes;
   const paperDotSizeVariance = // difference min/max size * 2
     Math.max(1, Math.max.apply(null, paperDotSizes) - Math.min.apply(null, paperDotSizes)) * 2;
   const avgPaperDotSize = paperDotSizes.reduce((sum, value) => sum + value) / paperDotSizes.length;
+  const markerSizeThreshold = avgPaperDotSize + paperDotSizeVariance;
 
   const videoMat = new cv.Mat(videoCapture.video.height, videoCapture.video.width, cv.CV_8UC4);
   videoCapture.read(videoMat);
@@ -204,10 +206,9 @@ export default function detectPrograms({
       keyPoint.colorIndex || colorIndexForColor(keyPoint.avgColor, config.colorsRGB);
   });
 
-  let [markers, keyPoints] = partition(
-    allPoints,
-    ({ size }) => size > avgPaperDotSize + paperDotSizeVariance
-  );
+  let [markers, keyPoints] = allBlobsAreKeyPoints
+    ? [[], allPoints]
+    : partition(allPoints, ({ size }) => size > markerSizeThreshold);
 
   // Sort by x position. We rely on this when scanning through the circles
   // to find connected components, and when calibrating.


### PR DESCRIPTION
when calibrating, any blob can be selected as a keypoint.

previously, only blobs that were within the keypoint size threshold
could be selected, leading to a chicken and the egg problem if your
keypoints were out of range to begin with.