### PR TITLE
enable wasm version of opencv

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -2,6 +2,8 @@ const api = require('./api');
 const express = require('express');
 const path = require('path');
 
+express.static.mime.types['wasm'] = 'application/wasm';
+
 process.on('unhandledRejection', error => {
   console.error('unhandledRejection', error.message); // eslint-disable-line no-console
 });


### PR DESCRIPTION
this adds the application/wasm mime type to the server, which  was stopping the wasm version from being used, resulting in a console warning and fallback to an ArrayBuffer version